### PR TITLE
Added queryType to options

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ const plugin = postcss.plugin('postcss-split-mq', options => {
     const updateContainers = createUpdaterFn(containers);
 
     // do the deed
-    CSS.walkAtRules('media', updateContainers);
+    CSS.walkAtRules(options.queryType || 'media', updateContainers);
 
     // write mq files
     await Promise.all(


### PR DESCRIPTION
Added queryType to options (with defaulting to 'media' if not provided). This way someone can also split the css file by other queries (e.g. 'supports').